### PR TITLE
Define empty state if initialState function not called

### DIFF
--- a/lib/with-state.js
+++ b/lib/with-state.js
@@ -146,7 +146,7 @@ define(function (require) {
         this.stateChanged = function () {};
 
         this.after('initialize', function () {
-            this._stateDef = (this._stateDef || function () {});
+            this._stateDef = (this._stateDef || function () { return {} });
             this.replaceState(this._stateDef.call(this));
         });
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flight-with-state",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "devDependencies": {
     "bower": "^1.3.3",
     "grunt": "~0.4.5",

--- a/test/spec/with-state.spec.js
+++ b/test/spec/with-state.spec.js
@@ -16,9 +16,11 @@ define(function (require) {
 
         var ComponentA;
         var ComponentB;
+        var ComponentC;
         var instanceAofA;
         var instanceBofA;
         var instanceAofB;
+        var instanceAofC;
 
         // Initialize a component and attach it to the DOM
         beforeEach(function () {
@@ -48,20 +50,29 @@ define(function (require) {
                 });
             });
 
+            ComponentC = makeComponent(function () {});
+
             instanceAofA = initializeComponent(ComponentA);
             instanceBofA = initializeComponent(ComponentA);
             instanceAofB = initializeComponent(ComponentB);
+            instanceAofC = initializeComponent(ComponentC);
         });
 
         afterEach(function () {
             ComponentA && ComponentA.teardownAll();
             ComponentB && ComponentB.teardownAll();
+            ComponentC && ComponentC.teardownAll();
         });
 
         describe('initialState', function () {
             it('should add this.state', function () {
                 expect(instanceAofA).toBeDefined();
                 expect(instanceAofA.state).toBeDefined();
+            });
+
+            it('should add empty state if initialState is not called', function () {
+                expect(instanceAofC).toBeDefined();
+                expect(instanceAofC.state).toEqual({});
             });
 
             it('propagates initialState to this.state', function () {


### PR DESCRIPTION
this.state, by definiton, is an object of key/values. It should
never be undefined. If no state has been set yet, this.state should
be an empty object.

NB: This is useful, because in with-observable-state we kinda *need* an initial state, otherwise we're pushing undefined values down the stream, and subscribers have to handle these individually. Another option is to make initialState a required call.