### PR TITLE
[#6] Pass old state to stateChanged

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ var ToggleButton = flight.component(
             });
         };
 
-        this.update = function () {
-            this.$node.toggleClass('is-active', this.state.active);
+        this.update = function (state, previousState) {
+            this.$node.toggleClass('is-active', state.active);
         };
     }
 );

--- a/src/index.js
+++ b/src/index.js
@@ -55,8 +55,11 @@ export default function withState() {
         if (!state || typeof state !== 'object') {
             return;
         }
+
+        const oldState = this.state;
+
         this.state = state;
-        this.stateChanged(this.state);
+        this.stateChanged(this.state, oldState);
         return this.state;
     };
 
@@ -139,8 +142,13 @@ export default function withState() {
 
     /**
      * Noop for advice around state changes.
+     *
+     * Having access to both the current `state`
+     * and `previousState` means you can add logic
+     * on state changes to decide whether you need
+     * to act on them or not (e.g. re-rendering).
      */
-    this.stateChanged = function () {};
+    this.stateChanged = function (state, previousState) {};
 
     this.after('initialize', function () {
         this._stateDef = (this._stateDef || noop);


### PR DESCRIPTION
Passing old `state` to `stateChanged` & adding some notes on the `stateChanged` no-op to signify you have access to both current `state` and `previousState`.

Closes #6.
